### PR TITLE
same versions of alpine, openresty, php as 0.5.0-php7.3.14-fpm-alpine3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -162,7 +162,7 @@ RUN set -ex \
 
 RUN rm -rf /var/cache/apk/*
 
-RUN mkdir -p /var/tmp/templates
+RUN mkdir -p /var/tmp/templates /var/tmp/nginx
 ADD templates/* /var/tmp/templates/
 ADD contrib/start.sh /var/tmp/start.sh
 RUN chmod 755 /var/tmp/start.sh 


### PR DESCRIPTION
readd directory /var/tmp/nginx that could cause downstream breakage if missing