### PR TITLE
bump version to php 7.4.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4.16-fpm-alpine3.13
+FROM php:7.4.19-fpm-alpine3.13
 
 # Docker Build Arguments
 ARG RESTY_VERSION="1.15.8.3"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ We use openresty for our nginx layer:
 
 RESTY_VERSION="1.15.8.3"
 
-#### FROM php:7.4.16-fpm-alpine3.13
+#### FROM php:7.4.19-fpm-alpine3.13
 
-valid tags: alpine-latest alpine-0.6.3 0.6.3-php7.4.16-fpm-alpine3.13
+valid tags: alpine-latest alpine-0.6.4 0.6.4-php7.4.19-fpm-alpine3.13
 


### PR DESCRIPTION
picks up security updates from 7.4.18 and reverts an issue introduced in 7.4.18 with 7.4.19